### PR TITLE
OVU-29 Corrects post is empty check

### DIFF
--- a/components/sidebar/sidebar.scss
+++ b/components/sidebar/sidebar.scss
@@ -22,6 +22,7 @@ h3.heading {
   @include font-props(16, 22, semibold);
   @include uppercase;
   color: $color-text-dark;
+  margin: 0;
 }
 
 .listWrapper {

--- a/services/postIsEmpty.js
+++ b/services/postIsEmpty.js
@@ -10,7 +10,7 @@ const postIsEmpty = () => {
   const content = getPostAttribute('content');
 
   // getEditedPostAttribute will return `undefined` or a string.
-  return !(title || content);
+  return (!title && !content);
 };
 
 export default postIsEmpty;

--- a/services/postIsEmpty.js
+++ b/services/postIsEmpty.js
@@ -10,10 +10,7 @@ const postIsEmpty = () => {
   const content = getPostAttribute('content');
 
   // getEditedPostAttribute will return `undefined` or a string.
-  return (
-    (title === undefined || title.length === 0)
-    && (content === undefined || content.length === 0)
-  );
+  return !(title || content);
 };
 
 export default postIsEmpty;


### PR DESCRIPTION
### **Overview:**
QA feedback found that keywords were not auto-fetched after one-of either a title OR content is entered. Also threw in a quick heading style fix for the Classic editor.
___

### **Links:**
https://alleyinteractive.atlassian.net/browse/OVU-29
___

### **PR checklist:**
- [x] **Unit tests**
  * PHPUnit tests have been added or extended to cover this feature or hotfix.
**OR**
  * This PR contains changes to code that are not testable at this time.
