### PR TITLE
OVU-140: Fixes heading color.

### DIFF
--- a/components/sidebar/noMatchCard/noMatchCard.scss
+++ b/components/sidebar/noMatchCard/noMatchCard.scss
@@ -16,12 +16,12 @@
   @include uppercase;
   background-color: $color-warn;
   border-radius: rem(4);
-  color: $color-white;
   margin: 0 0 rem(20) 0;
   padding: 0 rem(16);
 
   span {
     align-items: center;
+    color: $color-white;
     display: flex;
     height: rem(48);
   }


### PR DESCRIPTION
### **Overview:**

Quick hotfix to patch heading text color from QA review.
___

### **Links:**

https://alleyinteractive.atlassian.net/browse/OVU-140
___

### **PR checklist:**
- [x] **Unit tests**
  * PHPUnit tests have been added or extended to cover this feature or hotfix.
**OR**
  * This PR contains changes to code that are not testable at this time.
