### PR TITLE
OVU-153 Corrects the Save & Close vs. Close functionality

### DIFF
--- a/components/dialog/dialog.jsx
+++ b/components/dialog/dialog.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import saveState from 'services/saveState';
 import insertEmbed from 'services/insertEmbed';
-import { displayDismissableAlert } from 'services/alert';
+import { displayDismissableAlert, confirmThenProceed } from 'services/alert';
 import portalId from 'services/portalId';
 import withTrappedTabs from 'services/withTrappedTabs';
 import getPostAttribute from 'services/getPostAttribute';
@@ -47,6 +47,17 @@ const Dialog = ({
    */
   const closeButtonRef = useRef(null);
   const backToTopButtonRef = useRef(null);
+
+  /**
+   * Prompt the user with a confirm message prior to closing the dialog.
+   */
+  const promptToClose = () => {
+    confirmThenProceed(
+      { message: __('Are you sure you want exit the Oovvuu modal without saving?', 'oovvuu') },
+      __('Yes, close', 'oovvuu'),
+      closeDialog,
+    );
+  };
 
   /**
    * Handles the save action when a user clicks the save button.
@@ -153,7 +164,7 @@ const Dialog = ({
               ref={closeButtonRef}
               type="button"
               className={classnames(styles.closeButton, buttons.buttonIcon)}
-              onClick={closeDialog}
+              onClick={promptToClose}
               aria-label={__('Close', 'oovvuu')}
             >
               <span>

--- a/components/dialog/index.jsx
+++ b/components/dialog/index.jsx
@@ -3,7 +3,6 @@ import ActionButton from 'components/shared/actionButton';
 import getPostAttribute from 'services/getPostAttribute';
 import OovvuuDataContext from 'components/app/context';
 import OovvuuSmallSVGLogo from 'assets/oovvuu-small-logo.svg';
-import { confirmThenProceed } from 'services/alert';
 import TopicsPanelWrapper from './topicsPanel';
 import PositionsPanelWrapper from './positionsPanel';
 import KeywordPanel from './keywordPanel';
@@ -59,17 +58,6 @@ const DialogWrapper = () => {
     dispatch({ type: 'CLEAR_LOADING_STATE' });
   };
 
-  /**
-   * Prompt the user with a confirm message prior to closing the dialog.
-   */
-  const promptToClose = () => {
-    confirmThenProceed(
-      { message: __('Are you sure you want exit the Oovvuu modal without saving?', 'oovvuu') },
-      __('Yes, close', 'oovvuu'),
-      closeDialog,
-    );
-  };
-
   return (
     <>
       <ActionButton
@@ -87,7 +75,7 @@ const DialogWrapper = () => {
       <Dialog
         isOpen={isOpen}
         isLoading={isLoading}
-        closeDialog={promptToClose}
+        closeDialog={closeDialog}
       >
         <header className={styles.titleWrapper}>
           <h2 className={styles.postTitle}>


### PR DESCRIPTION
### **Overview:**
Corrects the function referenced by the `closeDialog` prop to correct the save/close routines.
___

### **Links:**
https://alleyinteractive.atlassian.net/browse/OVU-153
___

### **PR checklist:**
- [x] **Unit tests**
  * PHPUnit tests have been added or extended to cover this feature or hotfix.
**OR**
  * This PR contains changes to code that are not testable at this time.
